### PR TITLE
Add `pre-commit` configuration and hook installation instructions.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/psf/black
+    rev: 24.2.0
+    hooks:
+      - id: black
+      - id: black-jupyter
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        args: ["--prose-wrap", "always"]

--- a/README.md
+++ b/README.md
@@ -56,8 +56,20 @@ daytime/nighttime, on-peak/ off-peak)
 ### OSM data
 
 Data from open street maps is publicly maintained, so different areas will have
-different degrees of completeness. The [Python module OSMnx][OSMPy] can be used to fetch
-and visualize OSM data.
+different degrees of completeness. The [Python module OSMnx][OSMPy] can be used
+to fetch and visualize OSM data.
+
+## Contributing
+
+This project uses [`pre-commit`](https://pre-commit.com/) to ensure code
+formatting is consistent before committing. The currently-used hooks are:
+
+- [`black`](https://black.readthedocs.io/en/stable) for `*.py` or `*.ipynb`
+  files.
+- [`prettier`](https://prettier.io/) (with `--prose-wrap always` for markdown)
+
+To set up the hooks on your local machine, install `pre-commit`, then run
+`pre-commit install` to install the formatters that will run before each commit.
 
 [TOD]: https://open.toronto.ca/dataset/street-tree-data/
 [OSMPy]: https://pygis.io/docs/d_access_osm.html


### PR DESCRIPTION
From now on, it is easy to have your local code checked by an auto-formatter before a commit is made.