### PR TITLE
Fix typo in link reference (no broken links, just a markdown typo).

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ daytime/nighttime, on-peak/ off-peak)
 ### OSM data
 
 Data from open street maps is publicly maintained, so different areas will have
-different degrees of completeness. The [Python module OSMnx][OSMPy] can be used
+different degrees of completeness. The [Python module OSMnx][OSMnx] can be used
 to fetch and visualize OSM data.
 
 ## Contributing
@@ -72,4 +72,4 @@ To set up the hooks on your local machine, install `pre-commit`, then run
 `pre-commit install` to install the formatters that will run before each commit.
 
 [TOD]: https://open.toronto.ca/dataset/street-tree-data/
-[OSMPy]: https://pygis.io/docs/d_access_osm.html
+[OSMnx]: https://pygis.io/docs/d_access_osm.html


### PR DESCRIPTION
The link reference is `OSMPy` when `OSMnx` would be a more accurate and appropriate reference name.